### PR TITLE
Add support for redis client option

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ Potlock.configure do |config|
   config.redis_host = "localhost"
   config.redis_port = "6379"
   config.redis_db   = "1"
+  # or
+  # config.redis = Redis.new(host: "localhost", port: 6379, db: 1)
 end
 ```
 

--- a/lib/potlock/client.rb
+++ b/lib/potlock/client.rb
@@ -58,6 +58,8 @@ module Potlock
     end
 
     def redis
+      return Potlock.configuration.redis unless Potlock.configuration.redis.nil?
+
       @redis ||= Redis.new(
         host: Potlock.configuration.redis_host,
         db: Potlock.configuration.redis_db,

--- a/lib/potlock/configuration.rb
+++ b/lib/potlock/configuration.rb
@@ -3,7 +3,7 @@
 module Potlock
   class Configuration
     # Redis connection information
-    attr_accessor :redis_host, :redis_port, :redis_db
+    attr_accessor :redis, :redis_host, :redis_port, :redis_db
 
     # How many times it'll try to lock a resource
     attr_accessor :retry_count
@@ -12,9 +12,10 @@ module Potlock
     attr_accessor :retry_delay
 
     def initialize
-      @redis_host = "localhost"
-      @redis_port = "6379"
-      @redis_db   = "1"
+      @redis       = nil
+      @redis_host  = "localhost"
+      @redis_port  = "6379"
+      @redis_db    = "1"
       @retry_count = 25
       @retry_delay = 200
     end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -3,6 +3,14 @@
 RSpec.describe Potlock::Configuration do
   subject { described_class.new }
 
+  describe "redis" do
+    context "when no redis is specified" do
+      it "defaults to nil" do
+        expect(subject.redis).to be_nil
+      end
+    end
+  end
+
   describe "redis_host" do
     context "when no redis_host is specified" do
       it "defaults to Redis hostname" do

--- a/spec/potlock_spec.rb
+++ b/spec/potlock_spec.rb
@@ -1,15 +1,19 @@
 # frozen_string_literal: true
 
+require "mock_redis"
+
 RSpec.describe Potlock do
   describe "#configure" do
     it "allows Potlock configuration" do
       Potlock.configure do |config|
+        config.redis = MockRedis.new
         config.redis_host = "redis"
         config.redis_port = "6381"
         config.redis_db = "2"
         config.retry_count = 10
         config.retry_delay = 100
       end
+      expect(Potlock.configuration.redis).to be_an_instance_of(MockRedis)
       expect(Potlock.configuration.redis_host).to eq("redis")
       expect(Potlock.configuration.redis_port).to eq("6381")
       expect(Potlock.configuration.redis_db).to eq("2")


### PR DESCRIPTION
This PR adds support for a new `redis` option, in case we need more options than `host`, `port`, `db` (including another API compatible Redis client).